### PR TITLE
Fixes missing README.md & CHANGELOG when installing via pip/easy_install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+include CHANGELOG


### PR DESCRIPTION
Installing from PyPI fails because README.md and CHANGELOG are not included in the sdist tar.gz.
