### PR TITLE
Mark call to lirc_client.lirc_nextcode(...) as nogil

### DIFF
--- a/lirc/lirc.pyx
+++ b/lirc/lirc.pyx
@@ -222,7 +222,10 @@ def nextcode():
     _is_init_or_error()
 
     cdef char * code
-    if lirc_client.lirc_nextcode(&code) == -1:
+    cdef int return_value
+    with nogil:
+        return_value = lirc_client.lirc_nextcode(&code)
+    if return_value == -1:
         free(code)
         raise NextCodeError("There was an error reading the next code.")
     if code == NULL:

--- a/lirc/lirc_client.pxd
+++ b/lirc/lirc_client.pxd
@@ -12,5 +12,5 @@ cdef extern from "lirc/lirc_client.h":
     int lirc_readconfig(char *file,  lirc_config **config, void * check_callback)
     void lirc_freeconfig(lirc_config *config)
 
-    int lirc_nextcode(char **code)
+    int lirc_nextcode(char **code) nogil
     int lirc_code2char(lirc_config *config, char *code, char **string)


### PR DESCRIPTION
I had some problems using python-lirc: every time I called `lirc.nextcode()` (with blocking mode activated, because without blocking it makes busy-waiting which is pretty bad) in my python3 script, my whole program stopped working, even if I did this in a separate thread.

While debugging the problem I learned about the "biggest problem of python" (the GIL) and how complicated python multi-threading is because of it. 
As the problematic call is a native one from the lirc client library I assume that it is ok to mark it as `nogil`, when using only `cdef` (hence no-Python?) variables. 

With the changes in this pull request I was able to create a separate python thread that calls `lirc.nextcode()` in a loop that effectively did not had any effect on the MainTread regarding blocking the GIL. 

However I have to admit that my cython experience is very little. Hence that it works for me doesn't mean that it actually works without problems on all platforms. May be a more experienced cython programmer should look at the code and say if it is ok the way I changed it.

But as blocking the GIL has such a bad impact I thought that a non-GIL-blocking version of python-lirc would be useful for everybody.